### PR TITLE
feat!: remove flipper from the project

### DIFF
--- a/package.json
+++ b/package.json
@@ -44,7 +44,6 @@
     "@txo/types": "^1.7.0"
   },
   "peerDependencies": {
-    "@react-navigation/devtools": "^6.0.27",
     "@react-navigation/native": "^6.1.18",
     "@txo-peer-dep/log": "^4.0.4",
     "react-native": "*"
@@ -52,7 +51,6 @@
   "devDependencies": {
     "@babel/core": "^7.25.2",
     "@babel/preset-env": "^7.25.3",
-    "@react-navigation/devtools": "^6.0.27",
     "@react-navigation/native": "^6.1.18",
     "@txo-peer-dep/log": "^4.0.4",
     "@txo/commitlint": "^1.0.16",

--- a/src/Containers/InjectedNavigationContainer.tsx
+++ b/src/Containers/InjectedNavigationContainer.tsx
@@ -14,7 +14,6 @@ import {
   DarkTheme,
   type NavigationState,
 } from '@react-navigation/native'
-import { useFlipper } from '@react-navigation/devtools'
 
 import { useAndroidBackNavigation } from '../Hooks/UseAndroidBackNavigation'
 import {
@@ -41,7 +40,6 @@ export const InjectedNavigationContainer = ({
   onReady,
   onStateChange,
 }: Props): JSX.Element => {
-  useFlipper(navigationRef)
   useAndroidBackNavigation(navigationRef)
 
   useEffect(() => {

--- a/yarn.lock
+++ b/yarn.lock
@@ -2326,15 +2326,6 @@
     react-is "^16.13.0"
     use-latest-callback "^0.2.1"
 
-"@react-navigation/devtools@^6.0.27":
-  version "6.0.27"
-  resolved "https://registry.yarnpkg.com/@react-navigation/devtools/-/devtools-6.0.27.tgz#e64aac97f2da7bf7efe81f726e774fdc60117af6"
-  integrity sha512-ppeAz1cDGs9aIsAk6sHJtLTqLgtij1+qS3jWRAjLFBvx3urFdiIS73Ujq2Zmh+jPXmo+QpdD/A37x9vI095iLQ==
-  dependencies:
-    deep-equal "^2.0.5"
-    nanoid "^3.1.23"
-    stacktrace-parser "^0.1.10"
-
 "@react-navigation/native@^6.1.18":
   version "6.1.18"
   resolved "https://registry.yarnpkg.com/@react-navigation/native/-/native-6.1.18.tgz#338fa9afa2c89feec1d3eac41c963840d8d6f106"


### PR DESCRIPTION
BREAKING CHANGE: The Flipper integration was removed due to lack of use and to prevent enforcing installation of Flipper in the app.